### PR TITLE
Fix (naively) an issue about quote missing escape + Code styles

### DIFF
--- a/stickytape/__init__.py
+++ b/stickytape/__init__.py
@@ -144,6 +144,8 @@ def _read_file(path):
         return file.read()
 
 def _string_escape(string):
+    # Let's escape `'` before formatting the source blob within a long string literal.
+    string = string.replace('\'', '\\\'')
     return "'''{0}'''".format(codecs.getencoder(_py_string_encoding)(string)[0].decode("ascii"))
 
 def _is_stdlib_import(import_line):

--- a/stickytape/main.py
+++ b/stickytape/main.py
@@ -1,6 +1,5 @@
 import argparse
 import sys
-import subprocess
 
 import stickytape
 
@@ -14,8 +13,8 @@ def main():
 def _open_output(args):
     if args.output_file is None:
         return sys.stdout
-    else:
-        return open(args.output_file, "w")
+
+    return open(args.output_file, "w")
 
 def _parse_args():
     parser = argparse.ArgumentParser()
@@ -27,4 +26,3 @@ def _parse_args():
 
 if __name__ == "__main__":
     main()
-

--- a/stickytape/prelude.py
+++ b/stickytape/prelude.py
@@ -25,13 +25,12 @@ with __stickytape_temporary_dir() as __stickytape_working_dir:
                 if not os.path.exists(partial_path):
                     os.mkdir(partial_path)
                     open(os.path.join(partial_path, "__init__.py"), "w").write("\n")
-                    
+
         make_package(os.path.dirname(path))
-        
+
         full_path = os.path.join(__stickytape_working_dir, path)
         with open(full_path, "w") as module_file:
             module_file.write(contents)
 
     import sys as __stickytape_sys
     __stickytape_sys.path.insert(0, __stickytape_working_dir)
-

--- a/test_scripts/script_using_from_to_import_multiple_values/greeting.py
+++ b/test_scripts/script_using_from_to_import_multiple_values/greeting.py
@@ -1,4 +1,4 @@
-message = "Hello"
+message = """Hello '''some unintended quotes'''"""
 
 def print_stdout(value):
     print(value)

--- a/tests/stickytape_test.py
+++ b/tests/stickytape_test.py
@@ -58,7 +58,7 @@ def can_import_value_from_module_using_from_import_syntax():
 def can_import_multiple_values_from_module_using_from_import_syntax():
     test_script_output(
         script_path="script_using_from_to_import_multiple_values/hello",
-        expected_output=b"Hello\n"
+        expected_output=b"Hello '''some unintended quotes'''\n"
     )
 
 @istest

--- a/tests/stickytape_test.py
+++ b/tests/stickytape_test.py
@@ -142,7 +142,7 @@ def module_import_is_detected_when_import_is_renamed():
 def can_explicitly_set_python_interpreter():
     with _temporary_directory() as temp_path:
         venv_path = os.path.join(temp_path, "venv")
-        _shell.run(["virtualenv", venv_path])
+        _SHELL.run(["virtualenv", venv_path])
         site_packages_path = _find_site_packages(venv_path)
         path_path = os.path.join(site_packages_path, "greetings.pth")
         with open(path_path, "w") as path_file:
@@ -158,19 +158,19 @@ def can_explicitly_set_python_interpreter():
 def _find_site_packages(root):
     paths = []
 
-    for dir_path, dir_names, file_names in os.walk(root):
+    for dir_path, dir_names, _ in os.walk(root):
         for dir_name in dir_names:
             if dir_name == "site-packages":
                 paths.append(os.path.join(dir_path, dir_name))
 
     if len(paths) == 1:
         return paths[0]
-    else:
-        raise ValueError("Multiple site-packages found: {}".format(paths))
+
+    raise ValueError("Multiple site-packages found: {}".format(paths))
 
 
 
-_shell = spur.LocalShell()
+_SHELL = spur.LocalShell()
 
 
 @nottest
@@ -178,7 +178,7 @@ def test_script_output(script_path, expected_output, **kwargs):
     result = stickytape.script(find_script(script_path), **kwargs)
     with _temporary_script(result) as script_file_path:
         try:
-            output = _shell.run([script_file_path]).output
+            output = _SHELL.run([script_file_path]).output
         except:
             for index, line in enumerate(result.splitlines()):
                 print((index + 1), line)
@@ -196,7 +196,7 @@ def _temporary_script(contents):
         with open(path, "w") as script_file:
             script_file.write(contents)
 
-        _shell.run(["chmod", "+x", path])
+        _SHELL.run(["chmod", "+x", path])
         yield path
 
 


### PR DESCRIPTION
Hey there, while experiencing some stuffs with your code, I've encountered an issue with `'''` present within long string literals (i.e. `"""this '''is''' a test"""`).
They used to break the resulting code, as they were closing the source code blobs making output scripts unusable.

The single quote escape proposed _should_ fix this in a BC way.

On the other hand, as Pylint was running in the background, you'll find some (quick) "code styles" fixes.

:wave: