### PR TITLE
add asyncio as a core module

### DIFF
--- a/stickytape/__init__.py
+++ b/stickytape/__init__.py
@@ -477,6 +477,10 @@ _stdlib_modules = set([
 ])
 
 
+if sys.version_info[0] == 3:
+    _stdlib_modules.add("asyncio")
+
+
 if sys.version_info[0] == 2:
     _iteritems = lambda x: x.iteritems()
 


### PR DESCRIPTION
Not sure if this is the correct approach, or if we want to be less specific (ie place in broader list) or more (add subversion too?). stickytape isn't correctly handling asyncio as a dependency of a dependency.