### PR TITLE
Add base64 encoding + include module resources support

### DIFF
--- a/stickytape/__init__.py
+++ b/stickytape/__init__.py
@@ -3,6 +3,7 @@ import codecs
 import subprocess
 import ast
 import sys
+import base64
 
 
 def script(path, add_python_modules=None, add_python_paths=None, python_binary=None):
@@ -62,7 +63,7 @@ class ModuleWriterGenerator(object):
         for module_path, module_source in _iteritems(self._modules):
             output.append("    __stickytape_write_module({0}, {1})\n".format(
                 _string_escape(module_path),
-                _string_escape(module_source)
+                _string_escape(base64.encodebytes(module_source.encode(encoding='utf_8')))
             ))
         return "".join(output)
 

--- a/stickytape/main.py
+++ b/stickytape/main.py
@@ -10,6 +10,8 @@ def main():
         args.script,
         add_python_modules=args.add_python_module,
         add_python_paths=args.add_python_path,
+        add_resources_files=args.add_resources_file,
+        add_resources_modules=args.add_resources_module,
         python_binary=args.python_binary,
     )
     output_file.write(output)
@@ -25,6 +27,8 @@ def _parse_args():
     parser.add_argument("script")
     parser.add_argument("--add-python-module", action="append", default=[])
     parser.add_argument("--add-python-path", action="append", default=[])
+    parser.add_argument("--add-resources-module", action="append", default=[])
+    parser.add_argument("--add-resources-file", action="append", nargs=2, default=[])
     parser.add_argument("--python-binary")
     parser.add_argument("--output-file")
     return parser.parse_args()

--- a/stickytape/prelude.py
+++ b/stickytape/prelude.py
@@ -31,7 +31,7 @@ with __stickytape_temporary_dir() as __stickytape_working_dir:
 
         full_path = os.path.join(__stickytape_working_dir, path)
         with open(full_path, "wb") as module_file:
-            module_file.write(base64.decodebytes(contents))
+            module_file.write(base64.b64decode(contents))
 
     import sys as __stickytape_sys
     __stickytape_sys.path.insert(0, __stickytape_working_dir)

--- a/stickytape/prelude.py
+++ b/stickytape/prelude.py
@@ -16,6 +16,7 @@ def __stickytape_temporary_dir():
 with __stickytape_temporary_dir() as __stickytape_working_dir:
     def __stickytape_write_module(path, contents):
         import os, os.path
+        import base64
 
         def make_package(path):
             parts = path.split("/")
@@ -29,8 +30,8 @@ with __stickytape_temporary_dir() as __stickytape_working_dir:
         make_package(os.path.dirname(path))
 
         full_path = os.path.join(__stickytape_working_dir, path)
-        with open(full_path, "w") as module_file:
-            module_file.write(contents)
+        with open(full_path, "wb") as module_file:
+            module_file.write(base64.decodebytes(contents))
 
     import sys as __stickytape_sys
     __stickytape_sys.path.insert(0, __stickytape_working_dir)


### PR DESCRIPTION
These fixes enhance `stickytape` to include resources:

On the command line it is now possible to specify:

- `--add-resources-module` which will iterate over all the files in a specified module that are not python files and include in stickytape output
- `--add-resources-file` which includes a single resource file in the stickytape output

Base64 will of course add a bit of overhead in the stickytape output size, but it will be useful for binary files inclusion such as resources.