### PR TITLE
Explicitly close file after use

### DIFF
--- a/stickytape/prelude.py
+++ b/stickytape/prelude.py
@@ -24,7 +24,8 @@ with __stickytape_temporary_dir() as __stickytape_working_dir:
                 partial_path = os.path.join(partial_path, part)
                 if not os.path.exists(partial_path):
                     os.mkdir(partial_path)
-                    open(os.path.join(partial_path, "__init__.py"), "w").write("\n")
+                    with open(os.path.join(partial_path, "__init__.py"), "w") as f:
+                        f.write("\n")
 
         make_package(os.path.dirname(path))
 


### PR DESCRIPTION
fix #17 Holding of the __init__.py during 'make_package' cause failure on exit